### PR TITLE
jupyter_client 7.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "7.0.6" %}
+{% set version = "7.1.0" %}
 
 package:
   name: jupyter_client
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/j/jupyter_client/jupyter_client-{{ version }}.tar.gz
-  sha256: 8b6e06000eb9399775e0a55c52df6c1be4766666209c22f90c2691ded0e338dc
+  sha256: a5f995a73cffb314ed262713ae6dfce53c6b8216cea9f332071b8ff44a6e1654
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,7 +57,7 @@ test:
     - python -m pip check
     - jupyter kernelspec list
     - jupyter run -h
-    - pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail -k "not test_signal_kernel_subprocesses" --vv
+    - pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail -k "not test_signal_kernel_subprocesses" --v
 
 about:
   home: https://jupyter.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,12 +52,6 @@ test:
     - pytest-timeout
   imports:
     - jupyter_client
-  commands:
-    - python -m ipykernel install --user
-    - python -m pip check
-    - jupyter kernelspec list
-    - jupyter run -h
-    - pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail -k "not test_signal_kernel_subprocesses" --v
 
 about:
   home: https://jupyter.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ test:
     - coverage
     - ipykernel
     - ipython
-    # To fix tests on arm64
+    # Use ipython_genutils to fix tests on arm64 
     - ipython_genutils
     - mock
     - pip
@@ -52,6 +52,11 @@ test:
     - pytest-timeout
   imports:
     - jupyter_client
+    commands:
+    - python -m pip check
+    - jupyter kernelspec list
+    - jupyter run -h
+    - pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail -k "not test_signal_kernel_subprocesses"
 
 about:
   home: https://jupyter.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,10 +53,11 @@ test:
   imports:
     - jupyter_client
   commands:
+    - python -m ipykernel install --user
     - python -m pip check
     - jupyter kernelspec list
     - jupyter run -h
-    - pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail -k "not test_signal_kernel_subprocesses"
+    - pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail -k "not test_signal_kernel_subprocesses" --vv
 
 about:
   home: https://jupyter.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,7 @@ test:
     - pytest-timeout
   imports:
     - jupyter_client
-    commands:
+  commands:
     - python -m pip check
     - jupyter kernelspec list
     - jupyter run -h

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -10,4 +10,4 @@ jupyter kernelspec list
 
 jupyter run -h
 
-pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail --v
+pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -10,4 +10,4 @@ jupyter kernelspec list
 
 jupyter run -h
 
-pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered
+pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail --v


### PR DESCRIPTION
Update jupyter_client to 7.1.0

Version change: bump version number from 7.0.6 to 7.1.0
Bug Tracker: new open issues https://github.com/jupyter/jupyter_client/issues
Github releases:  https://github.com/jupyter/jupyter_client/releases
Upstream Changelog: https://github.com/jupyter/jupyter_client/blob/main/CHANGELOG.md
Upstream setup.py:  https://github.com/jupyter/jupyter_client/blob/v7.1.0/setup.py and https://github.com/jupyter/jupyter_client/blob/v7.1.0/requirements-test.txt 

The package jupyter_client is mentioned inside the packages:
glue-core | ipykernel | ipyparallel | jupyter_console | jupyter_kernel_gateway | jupyter_server | nbclient | nbsmoke | notebook | qtconsole | sas_kernel | spyder-kernels | spyder-kernels-0.2.4 | spyder-kernels-0.x |

Actions:
1. Improve a comment about using `ipython_genutils`

Result:
- all-succeeded