### PR TITLE
jupyter_client 7.1.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "7.1.0" %}
+{% set version = "7.1.2" %}
 
 package:
   name: jupyter_client
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/j/jupyter_client/jupyter_client-{{ version }}.tar.gz
-  sha256: a5f995a73cffb314ed262713ae6dfce53c6b8216cea9f332071b8ff44a6e1654
+  sha256: 4ea61033726c8e579edb55626d8ee2e6bf0a83158ddf3751b8dd46b2c5cd1e96
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,12 @@
+{% set name = "jupyter_client" %}
 {% set version = "7.1.2" %}
 
 package:
-  name: jupyter_client
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/j/jupyter_client/jupyter_client-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/jupyter_client-{{ version }}.tar.gz
   sha256: 4ea61033726c8e579edb55626d8ee2e6bf0a83158ddf3751b8dd46b2c5cd1e96
 
 build:
@@ -61,7 +62,7 @@ about:
   summary: jupyter_client contains the reference implementation of the Jupyter protocol.
   dev_url: https://github.com/jupyter/jupyter_client
   doc_url: https://jupyter-client.readthedocs.io/en/stable/
-  doc_source_url: https://github.com/jupyter/jupyter_client/tree/master/docs
+  doc_source_url: https://github.com/jupyter/{{ name }}/tree/v{{ version }}/docs
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Update jupyter_client to 7.1.2

Version change: bump version number from 7.1.0 to 7.1.2
Bug Tracker: new open issues https://github.com/jupyter/jupyter_client/issues
Github releases:  https://github.com/jupyter/jupyter_client/releases
Upstream Changelog: https://github.com/jupyter/jupyter_client/blob/main/CHANGELOG.md
Upstream setup.py:  https://github.com/jupyter/jupyter_client/blob/v7.1.2/setup.py Requirements: https://github.com/jupyter/jupyter_client/blob/v7.1.2/requirements.txt and https://github.com/jupyter/jupyter_client/blob/v7.1.2/requirements-test.txt 

The package jupyter_client is mentioned inside the packages:
glue-core | ipykernel | ipyparallel | jupyter_console | jupyter_kernel_gateway | jupyter_server | nbclient | nbsmoke | notebook | qtconsole | sas_kernel | spyder-kernels | spyder-kernels-0.2.4 | spyder-kernels-0.x |

Actions:
1. Use jinja2 templates in urls
2. Update doc_source_url

Result:
- all-succeeded