### PR TITLE
jupyter_client 7.2.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,9 +36,14 @@ requirements:
 test:
   requires:
     - async_generator
+    - codecov
+    - coverage
     - ipykernel
     - ipython
+    # Use ipython_genutils to fix tests on arm64 
+    - ipython_genutils
     - mock
+    - mypy
     - pip
     - pytest
     - pytest-asyncio
@@ -46,11 +51,6 @@ test:
     - pytest-timeout
   imports:
     - jupyter_client
-  commands:
-    - python -m pip check
-    - jupyter kernelspec list
-    - jupyter run -h
-    - pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail -k "not test_signal_kernel_subprocesses"
 
 about:
   home: https://jupyter.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   skip: True  # [py<37]
-  noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - jupyter-kernel = jupyter_client.kernelapp:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: 8fdbad344a8baa6a413d86d25bbf87ce21cb2b4aa5a8e0413863b9754eb8eb8a
 
 build:
+  number: 0
   skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,18 +35,18 @@ requirements:
     
 test:
   requires:
-    - async_generator
     - codecov
     - coverage
-    - ipykernel
+    - ipykernel >=6.5
     - ipython
     # Use ipython_genutils to fix tests on arm64 
-    - ipython_genutils
-    - mock
-    - mypy
+    - ipython_genutils  # [osx-arm64]
+    # mypy 0.910 has a missing dependency for python 3.7
+    - mypy <0.910  # [py==37]
+    - mypy  # [not py==37]
     - pip
     - pytest
-    - pytest-asyncio
+    - pytest-asyncio >=0.18
     - pytest-cov
     - pytest-timeout
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyter_client" %}
-{% set version = "7.1.2" %}
+{% set version = "7.2.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/jupyter_client-{{ version }}.tar.gz
-  sha256: 4ea61033726c8e579edb55626d8ee2e6bf0a83158ddf3751b8dd46b2c5cd1e96
+  sha256: 8fdbad344a8baa6a413d86d25bbf87ce21cb2b4aa5a8e0413863b9754eb8eb8a
 
 build:
-  number: 0
+  skip: True  # [py<37]
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
@@ -25,34 +25,33 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.6.1
+    - python
     - entrypoints
-    - jupyter_core >=4.6.0
-    - nest-asyncio >=1.5
-    - python-dateutil >=2.1
-    - pyzmq >=13
-    - tornado >=4.1
+    - jupyter_core >=4.9.2
+    - nest-asyncio >=1.5.4
+    - python-dateutil >=2.8.2
+    - pyzmq >=22.3
+    - tornado >=6.0
     - traitlets
     
 test:
   requires:
-    - python <3.10
     - async_generator
-    - codecov
-    - coverage
     - ipykernel
     - ipython
-    # Use ipython_genutils to fix tests on arm64 
-    - ipython_genutils
     - mock
     - pip
     - pytest
-    - mypy
     - pytest-asyncio
     - pytest-cov
     - pytest-timeout
   imports:
     - jupyter_client
+  commands:
+    - python -m pip check
+    - jupyter kernelspec list
+    - jupyter run -h
+    - pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail -k "not test_signal_kernel_subprocesses"
 
 about:
   home: https://jupyter.org

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -9,5 +9,5 @@ if errorlevel 1 exit 1
 jupyter run -h
 if errorlevel 1 exit 1
 
-pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered
+pytest -vv --pyargs jupyter_client
 if errorlevel 1 exit 1

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -21,7 +21,7 @@ elif [ "$(uname -m)" = "ppc64le" ]; then
 # RuntimeError: Kernel died before replying to kernel_info (on s390x)
 elif [ "$(uname -m)" = "s390x" ]; then
     pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail -k "not (test_start_parallel_process_kernels[tcp] \
-    test_signal_kernel_subprocesses[signaltest-_install_kernel-_ShutdownStatus.ShutdownRequest])" 
+    or test_signal_kernel_subprocesses[signaltest-_install_kernel-_ShutdownStatus.ShutdownRequest])" 
 else
     pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail 
 fi

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,13 +1,23 @@
 set -ex
 
-if [ "$(uname)" == "Darwin" ]; then
-    ulimit -n 4096
-fi
-
 python -m pip check
 
 jupyter kernelspec list
 
 jupyter run -h
 
-pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered
+if [ "$(uname)" == "Darwin" ]; then
+    ulimit -n 4096
+    pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail -k "not (test_install_kernel_spec_prefix)" 
+# Timeout issues with python 3.10 on ppc64le
+elif [ "$(uname -m)" = "ppc64le" ]; then
+    pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail \
+    -k "not (test_start_parallel_process_kernels[tcp] \
+    or test_async_signal_kernel_subprocesses[signaltest-_install_kernel-_ShutdownStatus.ShutdownRequest] \
+    or test_start_sequence_kernels[tcp] or test_start_sequence_kernels[ipc] \
+    or test_start_parallel_thread_kernels[tcp] \
+    or test_start_sequence_process_kernels[tcp] or test_signal_kernel_subprocesses \
+    or test_start_new_async_kernel)" 
+else
+    pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail 
+fi

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -14,16 +14,24 @@ elif [ "$(uname -m)" = "ppc64le" ]; then
     pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail \
     -k "not (test_start_parallel_process_kernels[tcp] \
     or test_async_signal_kernel_subprocesses[signaltest-_install_kernel-_ShutdownStatus.ShutdownRequest] \
-    or test_start_sequence_kernels[tcp] or test_start_sequence_kernels[ipc] \
+    or test_start_sequence_kernels[tcp] \ 
+    or test_start_sequence_kernels[ipc] \
     or test_start_parallel_thread_kernels[tcp] \
-    or test_start_sequence_process_kernels[tcp] or test_signal_kernel_subprocesses \
+    or test_start_sequence_process_kernels[tcp] \ 
+    or test_signal_kernel_subprocesses \
     or test_start_new_async_kernel)"
 # Timeout issues or RuntimeError: Kernel died before replying to kernel_info (on s390x)
 elif [ "$(uname -m)" = "s390x" ]; then
-    pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail -k "not (test_start_parallel_process_kernels[tcp] \
-    or test_signal_kernel_subprocesses[signaltest-_install_kernel-_ShutdownStatus.ShutdownRequest] \
-    or test_start_sequence_process_kernels[tcp] \
-    or test_start_sequence_kernels[tcp])" 
+    pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail \
+    -k "not (test_start_parallel_process_kernels[tcp] \
+    or test_async_signal_kernel_subprocesses[signaltest-_install_kernel-_ShutdownStatus.ShutdownRequest] \
+    or test_start_sequence_kernels[tcp] \ 
+    or test_start_sequence_kernels[ipc] \
+    or test_start_parallel_thread_kernels[tcp] \
+    or test_start_sequence_process_kernels[tcp] \ 
+    or test_signal_kernel_subprocesses \
+    or test_start_new_async_kernel
+    or test_shutdown)"
 else
     pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail 
 fi

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -18,7 +18,7 @@ elif [ "$(uname -m)" = "ppc64le" ]; then
     or test_start_parallel_thread_kernels[tcp] \
     or test_start_sequence_process_kernels[tcp] or test_signal_kernel_subprocesses \
     or test_start_new_async_kernel)"
-# RuntimeError: Kernel died before replying to kernel_info (on s390x)
+# Timeout issues or RuntimeError: Kernel died before replying to kernel_info (on s390x)
 elif [ "$(uname -m)" = "s390x" ]; then
     pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail -k "not (test_start_parallel_process_kernels[tcp] \
     or test_signal_kernel_subprocesses[signaltest-_install_kernel-_ShutdownStatus.ShutdownRequest] \

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -14,24 +14,19 @@ elif [ "$(uname -m)" = "ppc64le" ]; then
     pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail \
     -k "not (test_start_parallel_process_kernels[tcp] \
     or test_async_signal_kernel_subprocesses[signaltest-_install_kernel-_ShutdownStatus.ShutdownRequest] \
-    or test_start_sequence_kernels[tcp] \ 
-    or test_start_sequence_kernels[ipc] \
+    or test_start_sequence_kernels[tcp] or test_start_sequence_kernels[ipc] \
     or test_start_parallel_thread_kernels[tcp] \
-    or test_start_sequence_process_kernels[tcp] \ 
-    or test_signal_kernel_subprocesses \
+    or test_start_sequence_process_kernels[tcp] or test_signal_kernel_subprocesses \
     or test_start_new_async_kernel)"
 # Timeout issues or RuntimeError: Kernel died before replying to kernel_info (on s390x)
 elif [ "$(uname -m)" = "s390x" ]; then
     pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail \
     -k "not (test_start_parallel_process_kernels[tcp] \
     or test_async_signal_kernel_subprocesses[signaltest-_install_kernel-_ShutdownStatus.ShutdownRequest] \
-    or test_start_sequence_kernels[tcp] \ 
-    or test_start_sequence_kernels[ipc] \
+    or test_start_sequence_kernels[tcp] or test_start_sequence_kernels[ipc] \
     or test_start_parallel_thread_kernels[tcp] \
-    or test_start_sequence_process_kernels[tcp] \ 
-    or test_signal_kernel_subprocesses \
-    or test_start_new_async_kernel
-    or test_shutdown)"
+    or test_start_sequence_process_kernels[tcp] or test_signal_kernel_subprocesses \
+    or test_start_new_async_kernel or test_shutdown)"
 else
     pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail 
 fi

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -17,7 +17,10 @@ elif [ "$(uname -m)" = "ppc64le" ]; then
     or test_start_sequence_kernels[tcp] or test_start_sequence_kernels[ipc] \
     or test_start_parallel_thread_kernels[tcp] \
     or test_start_sequence_process_kernels[tcp] or test_signal_kernel_subprocesses \
-    or test_start_new_async_kernel)" 
+    or test_start_new_async_kernel)"
+# RuntimeError: Kernel died before replying to kernel_info (on s390x)
+elif [ "$(uname -m)" = "s390x" ]; then
+    pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail -k "not (test_start_parallel_process_kernels[tcp])" 
 else
     pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail 
 fi

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,5 +1,7 @@
 set -ex
 
+uname -m
+
 python -m pip check
 
 jupyter kernelspec list

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -26,7 +26,7 @@ elif [ "$(uname -m)" = "s390x" ]; then
     or test_start_sequence_kernels[tcp] or test_start_sequence_kernels[ipc] \
     or test_start_parallel_thread_kernels[tcp] \
     or test_start_sequence_process_kernels[tcp] or test_signal_kernel_subprocesses \
-    or test_start_new_async_kernel or test_shutdown)"
+    or test_start_new_async_kernel or test_shutdown or test_restart_check[tcp])"
 else
     pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail 
 fi

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,7 +1,5 @@
 set -ex
 
-uname -m
-
 python -m pip check
 
 jupyter kernelspec list
@@ -22,7 +20,8 @@ elif [ "$(uname -m)" = "ppc64le" ]; then
     or test_start_new_async_kernel)"
 # RuntimeError: Kernel died before replying to kernel_info (on s390x)
 elif [ "$(uname -m)" = "s390x" ]; then
-    pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail -k "not (test_start_parallel_process_kernels[tcp])" 
+    pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail -k "not (test_start_parallel_process_kernels[tcp] \
+    test_signal_kernel_subprocesses[signaltest-_install_kernel-_ShutdownStatus.ShutdownRequest])" 
 else
     pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail 
 fi

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -21,7 +21,8 @@ elif [ "$(uname -m)" = "ppc64le" ]; then
 # RuntimeError: Kernel died before replying to kernel_info (on s390x)
 elif [ "$(uname -m)" = "s390x" ]; then
     pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail -k "not (test_start_parallel_process_kernels[tcp] \
-    or test_signal_kernel_subprocesses[signaltest-_install_kernel-_ShutdownStatus.ShutdownRequest])" 
+    or test_signal_kernel_subprocesses[signaltest-_install_kernel-_ShutdownStatus.ShutdownRequest] \
+    or test_start_sequence_process_kernels[tcp])" 
 else
     pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail 
 fi

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -22,7 +22,8 @@ elif [ "$(uname -m)" = "ppc64le" ]; then
 elif [ "$(uname -m)" = "s390x" ]; then
     pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail -k "not (test_start_parallel_process_kernels[tcp] \
     or test_signal_kernel_subprocesses[signaltest-_install_kernel-_ShutdownStatus.ShutdownRequest] \
-    or test_start_sequence_process_kernels[tcp])" 
+    or test_start_sequence_process_kernels[tcp] \
+    or test_start_sequence_kernels[tcp])" 
 else
     pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail 
 fi


### PR DESCRIPTION
Update jupyter_client to 7.2.2

Version change: bump version number from 7.1.2 to 7.2.2
Bug Tracker: new open issues https://github.com/jupyter/jupyter_client/issues
Github releases: https://github.com/jupyter/jupyter_client/releases
Upstream Changelog: https://github.com/jupyter/jupyter_client/blob/main/CHANGELOG.md
Upstream setup.py: https://github.com/jupyter/jupyter_client/blob/v7.2.2/setup.py 
Requirements: 
- https://github.com/jupyter/jupyter_client/blob/v7.1.2/requirements.txt
- https://github.com/jupyter/jupyter_client/blob/v7.1.2/requirements-test.txt
- https://github.com/jupyter/jupyter_client/blob/v7.2.2/setup.py

The package jupyter_client is mentioned inside the packages:
glue-core | ipykernel | ipyparallel | jupyter_console | jupyter_kernel_gateway | jupyter_server | nbclient | nbsmoke | notebook | qtconsole | sas_kernel | spyder-kernels

Actions:
1. Remove `noarch`
2. Skip `py<37`
3. Fix `python` in run
4. Update `run` dependencies
5. Update and fix `test/requires`
6. Update tests: skip failing tests on `ppc64le` and `s390x`, use another `pytest` command for `win`