### PR TITLE
jupyter_client 7.4.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyter_client" %}
-{% set version = "7.3.5" %}
+{% set version = "7.4.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/jupyter_client-{{ version }}.tar.gz
-  sha256: 3c58466a1b8d55dba0bf3ce0834e4f5b7760baf98d1d73db0add6f19de9ecd1d
+  sha256: 63eae06c40e1f2d9afa14447511fddc065c95dea3f2491fda2acccf91221954a
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyter_client" %}
-{% set version = "7.4.5" %}
+{% set version = "7.4.6" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/jupyter_client-{{ version }}.tar.gz
-  sha256: 63eae06c40e1f2d9afa14447511fddc065c95dea3f2491fda2acccf91221954a
+  sha256: f7f9a9dc3a0ecd223ed6a5a00cf4140a5c252ec72e52d6de370748ed0aa083dd
 
 build:
   number: 0
@@ -43,9 +43,7 @@ test:
     - ipython
     # Use ipython_genutils to fix tests on arm64
     - ipython_genutils  # [osx-arm64]
-    # mypy 0.910 has a missing dependency for python 3.7
-    - mypy <0.910  # [py==37]
-    - mypy  # [not py==37]
+    - mypy
     - pip
     - pytest
     - pytest-asyncio >=0.18

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,8 @@ requirements:
   host:
     - pip
     - python
-    - hatchling >=0.25
+    - hatchling
+    - setuptools
     - wheel
   run:
     - python
@@ -38,7 +39,7 @@ test:
   requires:
     - codecov
     - coverage
-    - ipykernel >=6.5
+    - ipykernel >=6.12
     - ipython
     # Use ipython_genutils to fix tests on arm64
     - ipython_genutils  # [osx-arm64]
@@ -47,6 +48,7 @@ test:
     - mypy  # [not py==37]
     - pip
     - pytest
+    - pytest-asyncio >=0.18
     - pytest-cov
     - pytest-timeout
   imports:
@@ -57,10 +59,12 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: COPYING.md
-  summary: jupyter_client contains the reference implementation of the Jupyter protocol.
+  summary: Jupyter protocol implementation and client libraries.
+  description: |
+    jupyter_client contains the reference implementation of the Jupyter protocol. It also provides client and kernel management APIs for working with kernels.
+    It also provides the jupyter kernelspec entrypoint for installing kernelspecs for use with Jupyter frontends.
   dev_url: https://github.com/jupyter/jupyter_client
   doc_url: https://jupyter-client.readthedocs.io/en/stable/
-  doc_source_url: https://github.com/jupyter/{{ name }}/tree/v{{ version }}/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyter_client" %}
-{% set version = "7.4.6" %}
+{% set version = "7.4.7" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/jupyter_client-{{ version }}.tar.gz
-  sha256: f7f9a9dc3a0ecd223ed6a5a00cf4140a5c252ec72e52d6de370748ed0aa083dd
+  sha256: 330f6b627e0b4bf2f54a3a0dd9e4a22d2b649c8518168afedce2c96a1ceb2860
 
 build:
   number: 0

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -10,10 +10,10 @@ jupyter run -h
 
 if [ "$(uname)" == "Darwin" ]; then
     ulimit -n 4096
-    pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail -k "not (test_install_kernel_spec_prefix)" 
+    pytest --asyncio-mode=auto --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail -k "not (test_install_kernel_spec_prefix)" 
 # Timeout issues with python 3.10 on ppc64le
 elif [ "$(uname -m)" = "ppc64le" ]; then
-    pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail \
+    pytest --asyncio-mode=auto --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail \
     -k "not (test_start_parallel_process_kernels[tcp] \
     or test_async_signal_kernel_subprocesses[signaltest-_install_kernel-_ShutdownStatus.ShutdownRequest] \
     or test_start_sequence_kernels[tcp] or test_start_sequence_kernels[ipc] \
@@ -22,7 +22,7 @@ elif [ "$(uname -m)" = "ppc64le" ]; then
     or test_start_new_async_kernel)"
 # Timeout issues or RuntimeError: Kernel died before replying to kernel_info (on s390x)
 elif [ "$(uname -m)" = "s390x" ]; then
-    pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail \
+    pytest --asyncio-mode=auto --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail \
     -k "not (test_start_parallel_process_kernels[tcp] \
     or test_async_signal_kernel_subprocesses[signaltest-_install_kernel-_ShutdownStatus.ShutdownRequest] \
     or test_start_sequence_kernels[tcp] or test_start_sequence_kernels[ipc] \
@@ -30,5 +30,5 @@ elif [ "$(uname -m)" = "s390x" ]; then
     or test_start_sequence_process_kernels[tcp] or test_signal_kernel_subprocesses \
     or test_start_new_async_kernel or test_shutdown or test_restart_check[tcp])"
 else
-    pytest --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail 
+    pytest --asyncio-mode=auto --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail 
 fi

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,6 +1,8 @@
+#!/bin/bash
+
 set -ex
 
-python -m pip check
+$PYTHON -m pip check
 
 jupyter kernelspec list
 


### PR DESCRIPTION
**Jira ticket:** [PKG-686](https://anaconda.atlassian.net/browse/PKG-686) (jupyter_client-7.4.7)

**The upstream data:**
Github releases:  https://github.com/jupyter/jupyter_client/releases
Requirements:
 *  pyproject.toml:  https://github.com/jupyter/jupyter_client/blob/v7.4.7/pyproject.toml

**_Actions:_**

1. Remove `hatchling`'s pinning
2. Add `setuptools` to `host`
3. Update pinnings for `test/requires`
4. Update `summary`
5. Add a `description`
6. Remove `doc_source_url`
7. Fix `run_test.sh`
8. Update `pytest` command in `run_test.sh`


**Other checks:**

<details>

1. - [x] https://github.com/jupyter/jupyter_client/tree/v7.4.7 exists
9. - [x] https://jupyter.org is present
10. - [x] Check the pinnings
11. - [x] https://github.com/jupyter/jupyter_client/blob/main/CHANGELOG.md exists
12. - [x] Additional research
    https://github.com/jupyter/jupyter_client/issues
    200
13. - [x] `dev_url` is present
    https://github.com/jupyter/jupyter_client
14. - [x] `doc_url` is present
    https://jupyter-client.readthedocs.io/en/stable/
15. - [x] Verify that the `build_number` is correct
16. - [x] Verify if the package needs `setuptools`
    
17. - [x] has `wheel`
18. - [x] `pip` in tests
19. - [x] Verify the test section
20. - [x] Verify if the package is `architecture specific`
21. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
22.  - [x] license_file: COPYING.md is present
23. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |

24. - [x] license_family BSD is present
</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/jupyter_client-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/jupyter_client-feedstock/tree/7.4.7)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/jupyter_client)
* [Diff between upstream and feature branch](https://github.com/conda-forge/jupyter_client-feedstock/compare/main...AnacondaRecipes:7.4.7)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/jupyter_client-feedstock/compare/master...AnacondaRecipes:7.4.6)
* [The last merged PRs](https://github.com/AnacondaRecipes/jupyter_client-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 7.4.7 git@github.com:AnacondaRecipes/jupyter_client-feedstock.git
```
