### PR TITLE
jupyter_client 7.4.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/jupyter_client-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 109a3c33b62a9cf65aa8325850a0999a795fac155d9de4f7555aef5f310ee35a
 
 build:
@@ -62,7 +62,7 @@ about:
     jupyter_client contains the reference implementation of the Jupyter protocol. It also provides client and kernel management APIs for working with kernels.
     It also provides the jupyter kernelspec entrypoint for installing kernelspecs for use with Jupyter frontends.
   dev_url: https://github.com/jupyter/jupyter_client
-  doc_url: https://jupyter-client.readthedocs.io/en/stable/
+  doc_url: https://jupyter-client.readthedocs.io
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyter_client" %}
-{% set version = "7.4.7" %}
+{% set version = "7.4.8" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/jupyter_client-{{ version }}.tar.gz
-  sha256: 330f6b627e0b4bf2f54a3a0dd9e4a22d2b649c8518168afedce2c96a1ceb2860
+  sha256: 109a3c33b62a9cf65aa8325850a0999a795fac155d9de4f7555aef5f310ee35a
 
 build:
   number: 0


### PR DESCRIPTION
**Jira ticket:** [PKG-857](https://anaconda.atlassian.net/browse/PKG-857)(jupyter_client-7.4.8)

**The upstream data:**
Github releases:  https://github.com/jupyter/jupyter_client/releases
[Diff between the latest and previous upstream releases](https://github.com/jupyter/jupyter_client/compare/v7.4.7...v7.4.8)
Changelog: https://github.com/jupyter/jupyter_client/blob/main/CHANGELOG.md
Requirements:
 *  pyproject.toml:  https://github.com/jupyter/jupyter_client/blob/v7.4.8/pyproject.toml

**_Actions:_**

1. Fix `doc_url`

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority B | effort: hard | Category: anaconda | subcategory: dependency | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 7.4.8
 * Release on PyPi:
    * version: 7.4.8
    * date: 2022-12-05T11:28:52
* [PyPi history](https://pypi.org/project/jupyter_client/#history)
 * Popularity: 
    * 3 months downloads: 2332248.0
    * All time:  11673471 downloads -  jupyter_client  7.4.8  jupyter_client contains the reference implementation of the Jupyter protocol.  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/jupyter/jupyter_client/tree/v7.4.8 exists
8. - [x] Verify that the `build_number` is correct
9. - [x] has `setuptools`
10. - [x] has `wheel`
11. - [x] `pip` in test
12. - [x] Verify the test section
13. - [x] Verify if the package is `architecture specific`
14. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
15.  - [x] license_file: COPYING.md is present
16. - [x] license_family BSD is present
17. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |
</details>

**Check GUI app:**

<details>
**GUI app check**

Recommend to make testing in c3i_test2 channel!
../aggregate/jupyter_client is a GUI aplication

**End GUI check**

</details>

**Check dependency issues:**

<details>
../aggregate/jupyter_client-feedstock/recipe/meta.yaml
Dependencies: ['pip', 'entrypoints', 'python-dateutil >=2.8.2', 'tornado >=6.2', 'jupyter_core >=4.9.2', 'nest-asyncio >=1.5.4', 'python', 'setuptools', 'traitlets', 'pyzmq >=23.0', 'wheel', 'hatchling']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  Encountered problems while solving:
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0
  - nothing provides __glibc >=2.17 needed by libgcc-ng-11.2.0-h1234567_0

- py3.8:  Encountered problems while solving:
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0
  - nothing provides __glibc >=2.17 needed by libgcc-ng-11.2.0-h1234567_0

- py3.9:  Encountered problems while solving:
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0
  - nothing provides __glibc >=2.17 needed by libgcc-ng-11.2.0-h1234567_0

- py3.10:  Encountered problems while solving:
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0
  - nothing provides __glibc >=2.17 needed by libgcc-ng-11.2.0-h1234567_0


linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 18**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/jupyter_client-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/jupyter_client-feedstock/tree/7.4.8)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/jupyter_client)
* [Diff between upstream and feature branch](https://github.com/conda-forge/jupyter_client-feedstock/compare/main...AnacondaRecipes:7.4.8)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/jupyter_client-feedstock/compare/master...AnacondaRecipes:7.4.8)
* [The last merged PRs](https://github.com/AnacondaRecipes/jupyter_client-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 7.4.8 git@github.com:AnacondaRecipes/jupyter_client-feedstock.git
```
