### PR TITLE
Updated to 8.6.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyter_client" %}
-{% set version = "8.6.0" %}
+{% set version = "8.6.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/jupyter_client-{{ version }}.tar.gz
-  sha256: 0642244bb83b4764ae60d07e010e15f0e2d275ec4e918a8f7b80fbbef3ca60c7
+  sha256: 35b3a0947c4a6e9d589eb97d7d4cd5e90f910ee73101611f01283732bd6d9419
 
 build:
   number: 0
@@ -39,12 +39,17 @@ test:
     - ipykernel >=6.14
     - paramiko  # [win]
     - pip
-    - pytest
+    - pytest <8.2.0
     - pytest-jupyter-client >=0.4.1
     - pytest-cov
     - pytest-timeout
   imports:
     - jupyter_client
+    - jupyter_client.asynchronous
+    - jupyter_client.blocking
+    - jupyter_client.ioloop
+    - jupyter_client.provisioning
+    - jupyter_client.ssh
 
 about:
   home: https://jupyter.org
@@ -53,8 +58,9 @@ about:
   license_file: LICENSE
   summary: Jupyter protocol implementation and client libraries.
   description: |
-    jupyter_client contains the reference implementation of the Jupyter protocol. It also provides client and kernel management APIs for working with kernels.
-    It also provides the jupyter kernelspec entrypoint for installing kernelspecs for use with Jupyter frontends.
+    jupyter_client contains the reference implementation of the Jupyter protocol. It also provides client and kernel
+    management APIs for working with kernels. It also provides the jupyter kernelspec entrypoint for installing
+    kernelspecs for use with Jupyter frontends.
   dev_url: https://github.com/jupyter/jupyter_client
   doc_url: https://jupyter-client.readthedocs.io
 


### PR DESCRIPTION
jupyter_client 8.6.3

**Destination channel:** defaults

### Links

- [PKG-4304](https://anaconda.atlassian.net/browse/PKG-4304)
- [Upstream repository](https://github.com/jupyter/jupyter_client/tree/v8.6.3)
- [Upstream changelog/diff](https://github.com/jupyter/jupyter_client/blob/v8.6.3/CHANGELOG.md)

### Explanation of changes:

- Added more import tests
- Wrapped description at 120 characters
- Lacking `ipykernel` and `pytest-jupyter-client` to enable 3.13 support


[PKG-4304]: https://anaconda.atlassian.net/browse/PKG-4304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ