### PR TITLE
jupyter_client 8.6.3: Rebuild for py314

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
-
-channels:
-  - https://staging.continuum.io/pbp/fs/bcrypt-feedstock/pr7/65478bd
-  - https://staging.continuum.io/pbp/fs/paramiko-feedstock/pr12/17d5773

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,6 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
+
+channels:
+  - https://staging.continuum.io/pbp/fs/bcrypt-feedstock/pr7/65478bd
+  - https://staging.continuum.io/pbp/fs/paramiko-feedstock/pr12/17d5773

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,11 +36,13 @@ test:
   source_files:
     - tests
   requires:
-    - ipykernel >=6.14
+    # Skip py314 because ipykernel & pytest-jupyter-client are a circular dependency.
+    - ipykernel >=6.14  # [py<314]
+    - ipython
     - paramiko  # [win]
     - pip
     - pytest <8.2.0
-    - pytest-jupyter-client >=0.4.1
+    - pytest-jupyter-client >=0.4.1  # [py<314]
     - pytest-cov
     - pytest-timeout
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,11 +6,11 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/jupyter_client-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/jupyter_client-{{ version }}.tar.gz
   sha256: 35b3a0947c4a6e9d589eb97d7d4cd5e90f910ee73101611f01283732bd6d9419
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -12,7 +12,7 @@ if errorlevel 1 exit 1
 IF "%PY_VER%"=="3.14" (
 	    echo "WARNING: Skipping tests for Python 3.14. Remove it when ipykernel & pytest-jupyter-client are available for Python 3.14."
 ) ELSE (
-    pytest tests -vv --pyargs jupyter_client
+    pytest tests -vv --pyargs jupyter_client -k "not (test_start_parallel_process_kernels or test_async_signal_kernel_subprocesses[signaltest-_install_kernel-_ShutdownStatus.ShutdownRequest] or test_start_parallel_thread_kernels or test_input_request or test_load_ips or test_tcp_cinfo)"
 )
 
 

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -9,5 +9,11 @@ if errorlevel 1 exit 1
 jupyter run -h
 if errorlevel 1 exit 1
 
-pytest tests -vv --pyargs jupyter_client
+IF "%PY_VER%"=="3.14" (
+	    echo "WARNING: Skipping tests for Python 3.14. Remove it when ipykernel & pytest-jupyter-client are available for Python 3.14."
+) ELSE (
+    pytest tests -vv --pyargs jupyter_client
+)
+
+
 if errorlevel 1 exit 1

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -15,7 +15,7 @@ fi
 PYTHON_MINOR_VERSION=$(python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
 echo "PYTHON_MINOR_VERSION: $PYTHON_MINOR_VERSION"
 
-# Workaround for the python 3.14 build-out because ipykernel & pytest-jupyter-client are a circular dependency
+# Workaround for the python 3.14 build-out because ipykernel & pytest-jupyter-client are circular dependencies
 if [ "$PYTHON_MINOR_VERSION" == "3.14" ]; then
     echo "WARNING: Skipping tests for Python 3.14. Remove it when ipykernel & pytest-jupyter-client is available for Python 3.14."
 else

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -11,11 +11,20 @@ jupyter run -h
 if [ "$(uname)" == "Darwin" ]; then
     ulimit -n 4096
 fi
-# Timeout issues on most platforms
-pytest tests --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail -vv \
--k "not (test_start_parallel_process_kernels \
-or test_async_signal_kernel_subprocesses[signaltest-_install_kernel-_ShutdownStatus.ShutdownRequest] \
-or test_start_parallel_thread_kernels \
-or test_input_request \
-or test_load_ips \
-or test_tcp_cinfo)"
+
+PYTHON_MINOR_VERSION=$(python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+echo "PYTHON_MINOR_VERSION: $PYTHON_MINOR_VERSION"
+
+# Workaround for the python 3.14 build-out because ipykernel & pytest-jupyter-client are a circular dependency
+if [ "$PYTHON_MINOR_VERSION" == "3.14" ]; then
+    echo "WARNING: Skipping tests for Python 3.14. Remove it when ipykernel & pytest-jupyter-client is available for Python 3.14."
+else
+    # Timeout issues on most platforms
+    pytest tests --pyargs jupyter_client --cov jupyter_client --cov-report term-missing:skip-covered --no-cov-on-fail -vv \
+    -k "not (test_start_parallel_process_kernels \
+    or test_async_signal_kernel_subprocesses[signaltest-_install_kernel-_ShutdownStatus.ShutdownRequest] \
+    or test_start_parallel_thread_kernels \
+    or test_input_request \
+    or test_load_ips \
+    or test_tcp_cinfo)"
+fi


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-10732](https://anaconda.atlassian.net/browse/PKG-10732) 
- [Upstream repository](https://github.com/jupyter/jupyter_client/tree/v8.6.3)

### Explanation of changes:

- Add a workaround to skip tests for py314 because ipykernel & pytest-jupyter-client are circular dependencies

### Notes:

-

[PKG-10732]: https://anaconda.atlassian.net/browse/PKG-10732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ